### PR TITLE
[JENKINS-29844] Make PMD Plugin compatible with Workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jvnet.hudson.plugins</groupId>
     <artifactId>analysis-pom</artifactId>
-    <version>1.59</version>
+    <version>1.63</version>
   </parent>
 
   <artifactId>pmd</artifactId>
@@ -15,6 +15,10 @@
   <description>This plug-in generates the trend report for PMD, an
     open source static code analysis program.
   </description>
+
+  <properties>
+    <workflow-jenkins-plugin.version>1.4</workflow-jenkins-plugin.version>
+  </properties>
 
   <licenses>
     <license>
@@ -37,7 +41,7 @@
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
       <artifactId>analysis-core</artifactId>
-      <version>1.73-SNAPSHOT</version>
+      <version>1.73-beta-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.hudson.plugins</groupId>
@@ -70,6 +74,24 @@
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
       <version>2.11.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>${workflow-jenkins-plugin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <version>${workflow-jenkins-plugin.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <version>${workflow-jenkins-plugin.version}</version>
+     <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/hudson/plugins/pmd/PmdReporterResult.java
+++ b/src/main/java/hudson/plugins/pmd/PmdReporterResult.java
@@ -1,6 +1,7 @@
 package hudson.plugins.pmd;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.ParserResult;
 import hudson.plugins.analysis.core.ResultAction;
 import hudson.plugins.analysis.core.BuildResult;
@@ -28,9 +29,33 @@ public class PmdReporterResult extends PmdResult {
      * @param useStableBuildAsReference
      *            determines whether only stable builds should be used as
      *            reference builds or not
+     *
+     * @deprecated use {@link #PmdReporterResult(Run, String, ParserResult, boolean, boolean)}
      */
+    @Deprecated
     public PmdReporterResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final ParserResult result,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference);
+    }
+
+    /**
+     * Creates a new instance of {@link PmdReporterResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param result
+     *            the parsed result with all annotations
+     * @param usePreviousBuildAsReference
+     *            determines whether to use the previous build as the reference
+     *            build
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     */
+    public PmdReporterResult(final Run<?, ?> build, final String defaultEncoding, final ParserResult result,
+                             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
         super(build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference,
                 PmdMavenResultAction.class);
     }

--- a/src/main/java/hudson/plugins/pmd/PmdResult.java
+++ b/src/main/java/hudson/plugins/pmd/PmdResult.java
@@ -3,6 +3,7 @@ package hudson.plugins.pmd;
 import com.thoughtworks.xstream.XStream;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.BuildHistory;
 import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.analysis.core.ParserResult;
@@ -33,9 +34,33 @@ public class PmdResult extends BuildResult {
      * @param useStableBuildAsReference
      *            determines whether only stable builds should be used as
      *            reference builds or not
+     *
+     * @deprecated use {@link #PmdResult(Run, String, ParserResult, boolean, boolean, Class)}
      */
+    @Deprecated
     public PmdResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final ParserResult result,
             final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference);
+    }
+
+    /**
+     * Creates a new instance of {@link PmdResult}.
+     *
+     * @param build
+     *            the current build as owner of this action
+     * @param defaultEncoding
+     *            the default encoding to be used when reading and parsing files
+     * @param result
+     *            the parsed result with all annotations
+     * @param usePreviousBuildAsReference
+     *            determines whether to use the previous build as the reference
+     *            build
+     * @param useStableBuildAsReference
+     *            determines whether only stable builds should be used as
+     *            reference builds or not
+     */
+    public PmdResult(final Run<?, ?> build, final String defaultEncoding, final ParserResult result,
+                     final boolean usePreviousBuildAsReference, final boolean useStableBuildAsReference) {
         this(build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference, PmdResultAction.class);
     }
 
@@ -48,17 +73,47 @@ public class PmdResult extends BuildResult {
      * @param useStableBuildAsReference determines whether only stable builds should be used as
             reference builds or not
      * @param actionType the type of the result action
+     *
+     * @deprecated use {@link #PmdResult(Run, String, ParserResult, boolean, boolean, Class)}
      */
+    @Deprecated
     protected PmdResult(final AbstractBuild<?, ?> build,
             final String defaultEncoding, final ParserResult result,
             final boolean usePreviousBuildAsReference,
             final boolean useStableBuildAsReference,
             final Class<? extends ResultAction<PmdResult>> actionType) {
+        this((Run<?, ?>) build, defaultEncoding, result, usePreviousBuildAsReference, useStableBuildAsReference, actionType);
+    }
+
+    /**
+     * Creates a new instance of {@link PmdResult}.
+     *
+     * @param build the current build as owner of this action
+     * @param defaultEncoding the default encoding to be used when reading and parsing files
+     * @param result the parsed result with all annotations
+     * @param usePreviousBuildAsReference the value of usePreviousBuildAsReference
+     * @param useStableBuildAsReference determines whether only stable builds should be used as reference builds or not
+     * @param actionType the type of the result action
+     */
+    protected PmdResult(final Run<?, ?> build,
+                        final String defaultEncoding, final ParserResult result,
+                        final boolean usePreviousBuildAsReference,
+                        final boolean useStableBuildAsReference,
+                        final Class<? extends ResultAction<PmdResult>> actionType) {
         this(build, new BuildHistory(build, actionType, usePreviousBuildAsReference, useStableBuildAsReference), result, defaultEncoding, true);
     }
 
+    /**
+     *@deprecated use {@link #PmdResult(Run, BuildHistory, ParserResult, String, boolean)}
+     */
+    @Deprecated
     PmdResult(final AbstractBuild<?, ?> build, final BuildHistory history,
             final ParserResult result, final String defaultEncoding, final boolean canSerialize) {
+        this((Run<?, ?>) build, history, result, defaultEncoding, canSerialize);
+    }
+
+    PmdResult(final Run<?, ?> build, final BuildHistory history,
+              final ParserResult result, final String defaultEncoding, final boolean canSerialize) {
         super(build, history, result, defaultEncoding);
 
         if (canSerialize) {

--- a/src/main/java/hudson/plugins/pmd/PmdResultAction.java
+++ b/src/main/java/hudson/plugins/pmd/PmdResultAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.pmd;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.HealthDescriptor;
 import hudson.plugins.analysis.core.PluginDescriptor;
 import hudson.plugins.analysis.core.AbstractResultAction;
@@ -26,8 +27,25 @@ public class PmdResultAction extends AbstractResultAction<PmdResult> {
      *            health descriptor to use
      * @param result
      *            the result in this build
+     *
+     * @deprecated use {@link #PmdResultAction(Run, HealthDescriptor, PmdResult)}
      */
+    @Deprecated
     public PmdResultAction(final AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor, final PmdResult result) {
+        this((Run<?, ?>) owner, healthDescriptor, result);
+    }
+
+    /**
+     * Creates a new instance of <code>PmdResultAction</code>.
+     *
+     * @param owner
+     *            the associated build of this action
+     * @param healthDescriptor
+     *            health descriptor to use
+     * @param result
+     *            the result in this build
+     */
+    public PmdResultAction(final Run<?, ?> owner, final HealthDescriptor healthDescriptor, final PmdResult result) {
         super(owner, new PmdHealthDescriptor(healthDescriptor), result);
     }
 

--- a/src/test/java/hudson/plugins/pmd/PmdWorkflowTest.java
+++ b/src/test/java/hudson/plugins/pmd/PmdWorkflowTest.java
@@ -1,0 +1,78 @@
+package hudson.plugins.pmd;
+
+import hudson.FilePath;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PmdWorkflowTest {
+
+    @Rule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    /**
+     * Run a workflow job using {@link PmdPublisher} and check for success.
+     */
+    @Test
+    public void pmdPublisherWorkflowStep() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "pmdPublisherWorkflowStep");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("pmd.xml");
+        report.copyFrom(PmdWorkflowTest.class.getResourceAsStream("/hudson/plugins/pmd/parser/4-pmd-warnings.xml"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'PmdPublisher'])\n"
+                        + "}\n", true)
+        );
+        jenkinsRule.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        PmdResultAction result = job.getLastBuild().getAction(PmdResultAction.class);
+        assertEquals(4, result.getResult().getAnnotations().size());
+    }
+
+    /**
+     * Run a workflow job using {@link PmdPublisher} with a failing threshold of 0, so the given example file
+     * "/hudson/plugins/pmd/parser/4-pmd-warnings.xml" will make the build to fail.
+     */
+    @Test
+    public void pmdPublisherWorkflowStepSetLimits() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "pmdPublisherWorkflowStepSetLimits");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("pmd.xml");
+        report.copyFrom(PmdWorkflowTest.class.getResourceAsStream("/hudson/plugins/pmd/parser/4-pmd-warnings.xml"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'PmdPublisher', pattern: '**/pmd.xml', failedTotalAll: '0', usePreviousBuildAsReference: false])\n"
+                        + "}\n", true)
+        );
+        jenkinsRule.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
+        PmdResultAction result = job.getLastBuild().getAction(PmdResultAction.class);
+        assertEquals(4, result.getResult().getAnnotations().size());
+    }
+
+    /**
+     * Run a workflow job using {@link PmdPublisher} with a unstable threshold of 0, so the given example file
+     * "/hudson/plugins/pmd/parser/4-pmd-warnings.xml" will make the build to fail.
+     */
+    @Test
+    public void pmdPublisherWorkflowStepFailure() throws Exception {
+        WorkflowJob job = jenkinsRule.jenkins.createProject(WorkflowJob.class, "pmdPublisherWorkflowStepFailure");
+        FilePath workspace = jenkinsRule.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("pmd.xml");
+        report.copyFrom(PmdWorkflowTest.class.getResourceAsStream("/hudson/plugins/pmd/parser/4-pmd-warnings.xml"));
+        job.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  step([$class: 'PmdPublisher', pattern: '**/pmd.xml', unstableTotalAll: '0', usePreviousBuildAsReference: false])\n"
+                        + "}\n")
+        );
+        jenkinsRule.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
+        PmdResultAction result = job.getLastBuild().getAction(PmdResultAction.class);
+        assertEquals(4, result.getResult().getAnnotations().size());
+    }
+}
+


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/analysis-core-plugin/pull/31

Make PMD Plugin compatible with Workflow [JENKINS-29844](https://issues.jenkins-ci.org/browse/JENKINS-29844)

```
node {
  checkout changelog: false, poll: false, scm: [$class: 'SubversionSCM', additionalCredentials: [], excludedCommitMessages: '', excludedRegions: '', excludedRevprop: '', excludedUsers: '', filterChangelog: false, ignoreDirPropChanges: false, includedRegions: '', locations: [[credentialsId: 'efaa090d-5627-4a5c-95df-f570850d89a1', depthOption: 'infinity', ignoreExternalsOption: true, local: '.', remote: 'https://server/svn/repo/trunk']], workspaceUpdater: [$class: 'UpdateUpdater']]
  sh 'mvn clean install -Dmaven.test.skip pmd:check'
  step([$class: 'PmdPublisher'])
}
```

- [x] Initial source code modifications
- [x] Add an automated test specific for Workflow compatibility